### PR TITLE
Fix: Improve robustness of stringifyNode in parser

### DIFF
--- a/src/lib/parser/tree.ts
+++ b/src/lib/parser/tree.ts
@@ -183,7 +183,8 @@ export class Tree implements TreeObject {
     genTabs: ReturnType<typeof getGenTabsFn> = getGenTabsFn(options.tabWidth || 2),
   ): string {
     if (!isIterable(node)) {
-      const stringified = getRawValue(node)!;
+      // Use nullish coalescing to default to an empty string if getRawValue returns null/undefined, preventing potential errors.
+      const stringified = getRawValue(node) ?? "";
 
       if (!options.pure) {
         node.length = stringified.length;


### PR DESCRIPTION
I've safely handled potential undefined return values from getRawValue(node) in the stringifyNode function within src/lib/parser/tree.ts.

I changed `getRawValue(node)!` to `getRawValue(node) ?? ""`. This prevents a potential runtime TypeError by providing a default empty string if getRawValue(node) is null or undefined, without altering existing behavior in typical scenarios.

## Summary by Sourcery

Bug Fixes:
- Prevent potential TypeError in stringifyNode by defaulting getRawValue(node) to an empty string when it returns null or undefined