### PR TITLE
Fix: Replace non-existent jsonc-parser.parsePath with local implement…

### DIFF
--- a/src/lib/parser/tree.ts
+++ b/src/lib/parser/tree.ts
@@ -80,9 +80,12 @@ function _parseJsonPathString(pathString: string): (string | number)[] {
         segments.push(segment);
       }
     }
-    // If there's a leftover dot at the end of processing a segment (e.g. "prop."), advance past it.
+    // 如果在处理段的末尾有一个剩余的点（例如“prop.”），则将其视为格式错误的路径。
     if (i < path.length && path[i] === '.') {
-        i++;
+        throw new Error(`Malformed path: unexpected trailing dot at position ${i} in "${path}"`);
+        // 或者，如果您喜欢警告：
+        // console.warn(`Warning: Malformed path, unexpected trailing dot at position ${i} in "${path}"`);
+        // i++;
     }
   }
   return segments;


### PR DESCRIPTION
…ation.

This addresses an "Attempted import error: 'parsePath' is not exported from 'jsonc-parser'" in ./src/lib/parser/tree.ts.

I've implemented a new local helper function, _parseJsonPathString, in src/lib/parser/tree.ts to parse JSON path strings into an array of segments (string | number). This function handles dot-separated properties, array indices, and quoted keys.

The findNodeByPath method in the Tree class now uses this local_parseJsonPathString function.

Note: I couldn't execute automated tests for this change due to persistent timeouts during dependency installation (pnpm install). However, I reviewed the implementation against examples and requirements during development.

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

用自定义实现替换缺失的 `jsonc-parser.parsePath` 功能，并将其连接到树解析器中，以修复路径解析错误。

新特性：
- 引入本地 `_parseJsonPathString` 辅助函数，用于将 JSON 路径字符串解析为段

Bug 修复：
- 通过删除对不存在的 `jsonc-parser.parsePath` 的依赖来解决导入错误

增强功能：
- 更新 `Tree.findNodeByPath` 以使用新的本地解析器，并始终为空路径返回根节点

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the missing `jsonc-parser.parsePath` functionality with a custom implementation and wire it into the tree parser to fix path resolution errors.

New Features:
- Introduce a local `_parseJsonPathString` helper to parse JSON path strings into segments

Bug Fixes:
- Resolve import error by removing dependency on the non-existent `jsonc-parser.parsePath`

Enhancements:
- Update `Tree.findNodeByPath` to use the new local parser and consistently return the root for empty paths

</details>