### PR TITLE
fix: Correct folding model access in folding listener

### DIFF
--- a/src/lib/editor/editor.ts
+++ b/src/lib/editor/editor.ts
@@ -139,8 +139,8 @@ export class EditorWrapper {
       }
 
       const foldingController = this.editor.getContribution('editor.contrib.foldingController');
-      // The getFoldingModel method might be asynchronous or part of a sub-property.
-      const foldingModel = await (foldingController as any)?.getFoldingModel?.();
+      // Corrected: removed await, changed optional call to direct method call
+      const foldingModel = (foldingController as any)?.getFoldingModel(); 
 
       // Guard Clause: Condition B
       if (!foldingModel || typeof foldingModel.getRegionAtLine !== 'function' || typeof foldingModel.isCollapsed !== 'function') {


### PR DESCRIPTION
This commit addresses a bug where the synchronized folding feature was not working due to an error in accessing the Monaco editor's folding model.

The `listenOnDidChangeFolding` method in `EditorWrapper` was updated to correctly obtain the `foldingModel` from the `foldingController` by treating `getFoldingModel` as a synchronous method call. The `await` keyword and an unnecessary optional chaining on the method call were removed.

This change should resolve the console error:
"[main] listenOnDidChangeFolding: Folding model or required methods not available." and enable the synchronized fold/unfold functionality.